### PR TITLE
split functionalities to `installer` and `manager`, and other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,33 @@ This simple tool takes advantage of [`rustup`](https://github.com/rust-lang/rust
 
 ## Usage
 
-Run the executable as `./installer [OPTIONS] [COMMAND]`
+This program has seperated main functions, one is `installer` and one is `manager`.
+The `manager` binary is basically a renamed version of `installer` which will be written locally to the user machine after successully running `installer`.
+
+> this is a similar procedure done in rustup with its `rustup-init` and `rustup`.
+
+### Install
+
+Run the executable as `./installer [OPTIONS]`
+
+```console
+Options:
+  -v, --verbose        Enable verbose output
+  -q, --quiet          Suppress non-critical messages
+  -y, --yes            Disable interaction and answer 'yes' to all prompts
+      --prefix <PATH>  Set another path to install Rust
+  -h, --help           Print help
+  -V, --version        Print version
+```
+
+### Manage your installation
+
+Run the executable as `manager [OPTIONS] [COMMAND]`
 
 ```console
 Commands:
-  install    Install rustup, rust toolchain, and various tools
   uninstall  Uninstall individual components or everything
+  try-it     A subcommand to create a new Rust project template and let you start coding with it
   help       Print this message or the help of the given subcommand(s)
 
 Options:
@@ -24,20 +45,20 @@ Options:
   -V, --version  Print version
 ```
 
-### Install a set of tools
-
-TBD
-
-### Uninstallation
-
 1. uninstall selected tools:
 
 ```bash
-./installer uninstall tool [TOOLS]
+./manager uninstall tool [TOOLS]
 ```
 
 2. uninstall everything:
 
 ```bash
-./installer uninstall all
+./manager uninstall all
+```
+
+3. Export a pre-configured example project for you to try Rust:
+
+```bash
+./manager try-it -p /path/to/create/project
 ```

--- a/installer/src-tauri/src/components.rs
+++ b/installer/src-tauri/src/components.rs
@@ -55,7 +55,10 @@ pub fn get_component_list_from_manifest() -> Result<Vec<Component>> {
             .toolchain_component()
             .required(true),
     ];
-    let manifest = manifest::baked_in_manifest()?;
+
+    // TODO: Download manifest form remote server for online build
+    let mut manifest = manifest::baked_in_manifest()?;
+    manifest.adjust_paths()?;
 
     for toolchain_components in manifest.toolchain_components() {
         components.push(

--- a/installer/src/view/InstallView.vue
+++ b/installer/src/view/InstallView.vue
@@ -50,6 +50,14 @@ onMounted(() => {
       routerPush('/finish');
     }, 1000);
   });
+
+  event.listen('install-failed', (event) => {
+    if (typeof event.payload === 'string') {
+      output.value.push(event.payload);
+      toBottom();
+      // TODO: Handle installation failure here, showing the reason and let user exit the program.
+    }
+  });
 });
 </script>
 

--- a/resources/toolset_manifest.toml
+++ b/resources/toolset_manifest.toml
@@ -34,9 +34,9 @@ cargo-expand = "1.0.88"
 
 [tools.target.x86_64-unknown-linux-gnu]
 vscode = { path = "packages/x86_64-unknown-linux-gnu/code-stable-x64-1723659430.tar.gz", version = "1.91.1" }
-# cargo-llvm-cov = { url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.11/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz", version = "0.6.11" }
-# flamegraph = { git = "https://github.com/flamegraph-rs/flamegraph", tag = "v0.6.5" }
-# cargo-expand = "1.0.88"
+cargo-llvm-cov = { url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.11/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz", version = "0.6.11" }
+flamegraph = { git = "https://github.com/flamegraph-rs/flamegraph", tag = "v0.6.5" }
+cargo-expand = "1.0.88"
 
 [tools.target.aarch64-apple-darwin]
 cargo-llvm-cov = { url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.6.11/cargo-llvm-cov-aarch64-apple-darwin.tar.gz", version = "0.6.11" }

--- a/src/bin/installer.rs
+++ b/src/bin/installer.rs
@@ -1,7 +1,11 @@
 use anyhow::Result;
-use custom_rust_dist::cli;
+use clap::Parser;
+use custom_rust_dist::{cli, utils};
 
 fn main() -> Result<()> {
-    let cli = cli::parse_cli();
-    cli.execute()
+    match utils::lowercase_program_name() {
+        Some(s) if s.starts_with("manager") => cli::Manager::parse().execute(),
+        // Every thing else will fallback to installer mode
+        _ => cli::Installer::parse().execute(),
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,14 +9,50 @@ use clap::{Parser, Subcommand, ValueHint};
 use std::path::{Path, PathBuf};
 use url::Url;
 
-/// Master struct for command line args.
-///
+/// Install rustup, rust toolchain, and various tools.
 // NOTE: If you changed anything in this struct, or any other child types that related to
 // this struct, make sure the README doc is updated as well,
-// also make sure to update the cli section of `installer/src-tauri/tauri.conf.json`.
 #[derive(Parser, Default, Debug)]
 #[command(version, about)]
-pub struct CliOpt {
+pub struct Installer {
+    /// Enable verbose output
+    #[arg(short, long, conflicts_with = "quiet")]
+    pub verbose: bool,
+    /// Suppress non-critical messages
+    #[arg(short, long, conflicts_with = "verbose")]
+    pub quiet: bool,
+    /// Disable interaction and answer 'yes' to all prompts
+    #[arg(short, long = "yes")]
+    pub yes_to_all: bool,
+    #[cfg(feature = "gui")]
+    /// Don't show GUI when running the program.
+    #[arg(long)]
+    pub no_gui: bool,
+
+    /// Set another path to install Rust.
+    #[arg(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
+    pub prefix: Option<PathBuf>,
+    /// Specify another cargo registry url to replace `crates.io`, could be `sparse+URL`.
+    #[arg(hide = true, long)]
+    pub registry_url: Option<String>,
+    /// Specify another cargo registry name to replace `crates.io`.
+    #[arg(hide = true, long, default_value = "mirror")]
+    pub registry_name: String,
+    /// Specify another server to download Rust toolchain.
+    #[arg(hide = true, long, value_name = "URL", value_hint = ValueHint::Url)]
+    pub rustup_dist_server: Option<Url>,
+    /// Specify another server to download rustup.
+    #[arg(hide = true, long, value_name = "URL", value_hint = ValueHint::Url)]
+    pub rustup_update_root: Option<Url>,
+}
+
+/// Manage Rust installation, mostly used for uninstalling.
+// NOTE: If you changed anything in this struct, or any other child types that related to
+// this struct, make sure the README doc is updated as well,
+#[derive(Parser, Default, Debug)]
+#[command(version, about)]
+#[command(arg_required_else_help = true)]
+pub struct Manager {
     /// Enable verbose output
     #[arg(short, long, conflicts_with = "quiet")]
     pub verbose: bool,
@@ -31,20 +67,20 @@ pub struct CliOpt {
     #[arg(long)]
     pub no_gui: bool,
     #[command(subcommand)]
-    pub command: Option<Subcommands>,
+    pub command: Option<ManagerSubcommands>,
 }
 
-impl CliOpt {
+impl Installer {
     pub fn install_dir(&self) -> Option<&Path> {
-        self.command.as_ref().and_then(|cmd| {
-            if let Subcommands::Install { prefix, .. } = cmd {
-                prefix.as_deref()
-            } else {
-                None
-            }
-        })
+        self.prefix.as_deref()
     }
 
+    pub fn execute(&self) -> Result<()> {
+        install::execute_installer(self)
+    }
+}
+
+impl Manager {
     pub fn execute(&self) -> Result<()> {
         let global_opt = GlobalOpt {
             verbose: self.verbose,
@@ -55,8 +91,6 @@ impl CliOpt {
         if let Some(subcommand) = &self.command {
             subcommand.execute(global_opt)
         } else {
-            // Do nothing if no subcommand provided.
-            // Note that options like `--version`, `--help` are already handled by `clap`.
             Ok(())
         }
     }
@@ -64,25 +98,9 @@ impl CliOpt {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Subcommand, Debug)]
-pub enum Subcommands {
-    /// Install rustup, rust toolchain, and various tools.
-    Install {
-        /// Set another path to install Rust.
-        #[arg(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
-        prefix: Option<PathBuf>,
-        /// Specify another cargo registry url to replace `crates.io`, could be `sparse+URL`.
-        #[arg(hide = true, long)]
-        registry_url: Option<String>,
-        /// Specify another cargo registry name to replace `crates.io`.
-        #[arg(hide = true, long, default_value = "mirror", value_hint = ValueHint::Url)]
-        registry_name: String,
-        /// Specify another server to download Rust toolchain.
-        #[arg(hide = true, long, value_name = "URL", value_hint = ValueHint::Url)]
-        rustup_dist_server: Option<Url>,
-        /// Specify another server to download rustup.
-        #[arg(hide = true, long, value_name = "URL", value_hint = ValueHint::Url)]
-        rustup_update_root: Option<Url>,
-    },
+#[command(arg_required_else_help = true)]
+pub enum ManagerSubcommands {
+    // TODO: Add install command to install **individual** components.
     /// Uninstall individual components or everything.
     Uninstall {
         #[command(subcommand)]
@@ -96,9 +114,8 @@ pub enum Subcommands {
     },
 }
 
-impl Subcommands {
+impl ManagerSubcommands {
     pub(crate) fn execute(&self, opt: GlobalOpt) -> Result<()> {
-        install::execute(self, opt)?;
         uninstall::execute(self, opt)?;
         tryit::execute(self, opt)?;
         Ok(())
@@ -127,6 +144,10 @@ pub struct GlobalOpt {
     pub yes: bool,
 }
 
-pub fn parse_cli() -> CliOpt {
-    CliOpt::parse()
+pub fn parse_installer_cli() -> Installer {
+    Installer::parse()
+}
+
+pub fn parse_manager_cli() -> Manager {
+    Manager::parse()
 }

--- a/src/cli/tryit.rs
+++ b/src/cli/tryit.rs
@@ -1,10 +1,10 @@
-use super::{GlobalOpt, Subcommands};
+use super::{GlobalOpt, ManagerSubcommands};
 use crate::core::try_it;
 use anyhow::Result;
 
 /// Execute `install` command.
-pub(super) fn execute(subcommand: &Subcommands, _opt: GlobalOpt) -> Result<()> {
-    let Subcommands::TryIt { path } = subcommand else {
+pub(super) fn execute(subcommand: &ManagerSubcommands, _opt: GlobalOpt) -> Result<()> {
+    let ManagerSubcommands::TryIt { path } = subcommand else {
         return Ok(());
     };
 

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -3,13 +3,13 @@
 use crate::cli::UninstallCommand;
 use crate::core::uninstall::{UninstallConfiguration, Uninstallation};
 
-use super::{GlobalOpt, Subcommands};
+use super::{GlobalOpt, ManagerSubcommands};
 
 use anyhow::Result;
 
 /// Execute `uninstall` command.
-pub(super) fn execute(subcommand: &Subcommands, _opt: GlobalOpt) -> Result<()> {
-    let Subcommands::Uninstall {
+pub(super) fn execute(subcommand: &ManagerSubcommands, _opt: GlobalOpt) -> Result<()> {
+    let ManagerSubcommands::Uninstall {
         commands: Some(uninst_cmd),
     } = subcommand
     else {

--- a/src/core/custom_instructions/buildtools.rs
+++ b/src/core/custom_instructions/buildtools.rs
@@ -48,7 +48,7 @@ pub(super) fn install(path: &Path, config: &InstallConfiguration) -> Result<()> 
     // Step 2.5: Make a copy of this installer to the `tools` directory,
     // which is later used for uninstallation.
     let installer_dir = config.tools_dir().join("buildtools");
-    utils::mkdirs(&installer_dir)?;
+    utils::ensure_dir(&installer_dir)?;
     utils::copy_file_to(&buildtools_exe, &installer_dir)?;
 
     // Step 3: Invoke the install command.

--- a/src/core/custom_instructions/vscode.rs
+++ b/src/core/custom_instructions/vscode.rs
@@ -110,7 +110,7 @@ Keywords=vscode;
                 show_no_folder_warning();
                 return Ok(());
             };
-            let _ = utils::mkdirs(&path_to_write);
+            let _ = utils::ensure_dir(&path_to_write);
             path_to_write.push(format!("{}.desktop", self.cmd));
             if utils::write_file(&path_to_write, &desktop_sc, false).is_err() {
                 show_failure_warning();

--- a/src/core/os/windows.rs
+++ b/src/core/os/windows.rs
@@ -95,7 +95,7 @@ pub(crate) mod rustup {
         })
     }
 
-    pub(crate) fn do_add_to_programs(bin_dir: &Path) -> Result<()> {
+    pub(crate) fn do_add_to_programs(program_bin: &Path) -> Result<()> {
         use std::path::PathBuf;
 
         let key = RegKey::predef(HKEY_CURRENT_USER)
@@ -115,14 +115,8 @@ pub(crate) mod rustup {
             }
         }
 
-        let cur_exe_path = env::current_exe()?;
-        let exe_name = cur_exe_path
-            .file_name()
-            .unwrap_or_else(|| unreachable!("executable should always have a filename"));
-        let path = bin_dir.join(exe_name);
-
         let mut uninstall_cmd = OsString::from("\"");
-        uninstall_cmd.push(path);
+        uninstall_cmd.push(program_bin);
         uninstall_cmd.push("\"");
 
         // FIXME: Remove this if the GUI app supports uninstallation with ui.

--- a/src/core/rustup.rs
+++ b/src/core/rustup.rs
@@ -78,7 +78,7 @@ impl Rustup {
         // Install rustup.
         self.generate_rustup(&rustup_init)?;
         // Install rust toolchain via rustup.
-        let rustup = config.cargo_home().join("bin").join(RUSTUP);
+        let rustup = config.cargo_bin().join(RUSTUP);
         self.download_rust_toolchain(&rustup, manifest)?;
 
         // Install extral rust component via rustup.

--- a/src/core/try_it.rs
+++ b/src/core/try_it.rs
@@ -68,8 +68,8 @@ impl<'a> ExampleTemplate<'a> {
         let root = dest.join("example_project");
         let src_dir = root.join("src");
         let vscode_dir = root.join(".vscode");
-        utils::mkdirs(&src_dir)?;
-        utils::mkdirs(&vscode_dir)?;
+        utils::ensure_dir(&src_dir)?;
+        utils::ensure_dir(&vscode_dir)?;
 
         let main_fp = src_dir.join("main.rs");
         let cargo_toml_fp = root.join("Cargo.toml");

--- a/src/utils/extraction.rs
+++ b/src/utils/extraction.rs
@@ -105,7 +105,7 @@ fn extract_zip<T: Sized>(path: &Path, root: &Path, indicator: ProgressIndicator<
         };
 
         if zip_file.is_dir() {
-            super::mkdirs(&out_path)?;
+            super::ensure_dir(&out_path)?;
         } else {
             super::ensure_parent_dir(&out_path)?;
             let mut out_file = std::fs::File::create(&out_path)?;
@@ -178,7 +178,7 @@ fn extract_7z<T: Sized>(path: &Path, root: &Path, indicator: ProgressIndicator<T
         let out_path = root.join(&entry_path);
 
         if entry.is_directory() {
-            super::mkdirs(&out_path).map_err(|_| {
+            super::ensure_dir(&out_path).map_err(|_| {
                 sevenz_rust::Error::other(format!(
                     "unable to create entry directory '{}'",
                     out_path.display()
@@ -264,7 +264,7 @@ fn extract_tar<T: Sized, R: Read>(
         let out_path = root.join(&entry_path);
 
         if entry.header().entry_type().is_dir() {
-            super::mkdirs(&out_path).with_context(|| {
+            super::ensure_dir(&out_path).with_context(|| {
                 format!(
                     "failed to create directory when extracting '{}'",
                     path.display()

--- a/src/utils/file_system.rs
+++ b/src/utils/file_system.rs
@@ -35,20 +35,21 @@ pub fn stringify_path<P: AsRef<Path>>(path: P) -> Result<String> {
         })
 }
 
-pub fn mkdirs<P: AsRef<Path>>(path: P) -> Result<()> {
-    fs::create_dir_all(path.as_ref()).with_context(|| {
-        format!(
-            "unable to create specified directory '{}'",
-            path.as_ref().display()
-        )
-    })
+pub fn ensure_dir<P: AsRef<Path>>(path: P) -> Result<()> {
+    if !path.as_ref().is_dir() {
+        fs::create_dir_all(path.as_ref()).with_context(|| {
+            format!(
+                "unable to create specified directory '{}'",
+                path.as_ref().display()
+            )
+        })?;
+    }
+    Ok(())
 }
 
 pub fn ensure_parent_dir<P: AsRef<Path>>(path: P) -> Result<()> {
     if let Some(p) = path.as_ref().parent() {
-        if !p.exists() {
-            mkdirs(p)?;
-        }
+        ensure_dir(p)?;
     }
     Ok(())
 }
@@ -150,8 +151,6 @@ where
 }
 
 /// Copy file or directory to a specified path.
-///
-/// Similar to [`copy_file_to`], except this will recursively copy directory as well.
 pub fn copy_as<P, Q>(from: P, to: Q) -> Result<()>
 where
     P: AsRef<Path>,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,7 +9,7 @@ mod file_system;
 mod process;
 mod progress_bar;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub use download::download_from_start;
 pub use extraction::{Extractable, ExtractableKind};
@@ -18,6 +18,11 @@ pub use process::*;
 
 use anyhow::Result;
 use url::Url;
+
+#[cfg(not(windows))]
+pub const EXE_EXT: &str = "";
+#[cfg(windows)]
+pub const EXE_EXT: &str = ".exe";
 
 /// Forcefully parsing a `&str` to [`Url`].
 ///
@@ -54,4 +59,13 @@ pub fn path_to_str(path: &Path) -> Result<&str> {
             path.display()
         )
     })
+}
+
+/// Get the binary name of current executing binary, a.k.a `arg[0]`.
+pub fn lowercase_program_name() -> Option<String> {
+    let program_executable = std::env::args().next().map(PathBuf::from)?;
+    let program_name = program_executable
+        .file_name()
+        .and_then(|oss| oss.to_str())?;
+    Some(program_name.to_lowercase())
 }

--- a/tests/extraction.rs
+++ b/tests/extraction.rs
@@ -11,7 +11,7 @@ fn extract_to_temp(filename: &str) -> TempDir {
     let cache_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("cache");
-    utils::mkdirs(&cache_dir).unwrap();
+    utils::ensure_dir(&cache_dir).unwrap();
 
     let temp_dir = tempfile::Builder::new()
         .prefix("extract_test_")


### PR DESCRIPTION
split functionalities to `installer` and `manager`, where `installer` doesn't have the ability to uninstall;
temporarily disable uninstalling with release build;
display installation error on GUI;

related: #60 
related: #51 comment _Originally posted by @surechen in https://github.com/J-ZhengLi/custom-rust-dist/issues/51#issuecomment-2298219361_