### PR TITLE
fix various bugs & some refractoring

### DIFF
--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -22,9 +22,6 @@ rim = { path = "../..", features = [ "gui" ] }
 indexmap.workspace = true
 rust-i18n.workspace = true
 
-[target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = ["wincon"] }
-
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]

--- a/installer/src-tauri/src/installer_mode.rs
+++ b/installer/src-tauri/src/installer_mode.rs
@@ -1,5 +1,5 @@
 use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use std::thread;
@@ -14,7 +14,7 @@ use crate::error::Result;
 use rim::components::{get_component_list_from_manifest, Component};
 use rim::toolset_manifest::{baked_in_manifest, ToolInfo};
 use rim::utils::Progress;
-use rim::{try_it, utils, EnvConfig, InstallConfiguration};
+use rim::{try_it, utils, InstallConfiguration};
 
 static LOG_FILE: OnceLock<PathBuf> = OnceLock::new();
 
@@ -86,15 +86,37 @@ fn install_toolchain(
     components_list: Vec<Component>,
     install_dir: String,
 ) -> Result<()> {
+    // 使用 Arc 来共享 window
+    let window = Arc::new(window);
+    let window_clone = Arc::clone(&window);
+    let log_path = log_file_path(&install_dir);
+
+    // 在一个新线程中执行安装过程
+    let install_thread = spawn_install_thread(window, components_list, install_dir, log_path)?;
+    // 在主线程中接收进度并发送事件
+    let gui_thread = spawn_gui_update_thread(window_clone, install_thread, log_path);
+
+    if gui_thread.is_finished() {
+        gui_thread.join().expect("unable to join GUI thread")?;
+    }
+    Ok(())
+}
+
+fn spawn_install_thread(
+    win: Arc<tauri::Window>,
+    components: Vec<Component>,
+    install_dir: String,
+    log_path: &'static Path,
+) -> Result<thread::JoinHandle<anyhow::Result<()>>> {
     // Split components list to `toolchain_components` and `toolset_components`,
     // as we are running `rustup` to install toolchain components.
     let toolset_components = component_list_to_map(
-        components_list
+        components
             .iter()
             .filter(|cm| !cm.is_toolchain_component)
             .collect(),
     );
-    let toolchain_components: Vec<String> = components_list
+    let toolchain_components: Vec<String> = components
         .into_iter()
         // Skip the mocked `rust toolchain` component that we added first,
         // it will be installed as requirement anyway.
@@ -108,24 +130,12 @@ fn install_toolchain(
         })
         .collect();
 
-    // FIXME: Don't use manifest here, instead, load everything we need to `component`
-    let manifest = baked_in_manifest()?;
-
-    // 使用 Arc 来共享 window
-    let window = Arc::new(window);
-    // 克隆 Arc
-    let window_clone = Arc::clone(&window);
-
-    // 在一个新线程中执行安装过程
-    let install_thread = thread::spawn(move || -> anyhow::Result<()> {
-        let log_file = LOG_FILE.get_or_init(|| PathBuf::from(&install_dir).join("install.log"));
-        utils::ensure_parent_dir(log_file)?;
+    Ok(thread::spawn(move || -> anyhow::Result<()> {
         let file = std::fs::OpenOptions::new()
             .truncate(true)
             .create(true)
-            .read(true)
             .write(true)
-            .open(log_file)?;
+            .open(log_path)?;
         // Here we redirect all console output during installation to a buffer
         // Note that `rustup` collect `info:` strings in stderr.
         let drop_with_care = capture_output_to_file(file)?;
@@ -134,62 +144,52 @@ fn install_toolchain(
         let msg_cb = |msg: String| -> anyhow::Result<()> {
             // Note: a small timeout to make sure the message are emitted properly.
             thread::sleep(Duration::from_millis(100));
-            Ok(window.emit("install-details", msg)?)
+            Ok(win.emit("install-details", msg)?)
         };
-        let pos_cb = |pos: f32| -> anyhow::Result<()> { Ok(window.emit("install-progress", pos)?) };
+        let pos_cb = |pos: f32| -> anyhow::Result<()> { Ok(win.emit("install-progress", pos)?) };
         let progress = Progress::new(&msg_cb, &pos_cb);
 
         // TODO: Use continuous progress
-        let mut config =
-            InstallConfiguration::init(Path::new(&install_dir), false, Some(progress))?;
-        config.config_env_vars(&manifest)?;
-        config.config_cargo()?;
-        // This step taking cares of requirements, such as `MSVC`, also third-party app such as `VS Code`.
-        config.install_tools(&manifest, &toolset_components)?;
-        config.install_rust(&manifest, &toolchain_components)?;
-        // install third-party tools via cargo that got installed by rustup
-        config.cargo_install(&toolset_components)?;
+        InstallConfiguration::init(Path::new(&install_dir), false, Some(progress))?
+            .install(toolchain_components, toolset_components)?;
 
-        // Manually drop this, to tell instruct the thread stop capturing output.
+        // Manually drop this, to stop capturing output to file.
         drop(drop_with_care);
 
         // 安装完成后，发送安装完成事件
-        window.emit("install-complete", ())?;
+        win.emit("install-complete", ())?;
 
         Ok(())
-    });
+    }))
+}
 
-    // 在主线程中接收进度并发送事件
-    let log_collector_thread = thread::spawn(move || -> anyhow::Result<()> {
-        let mut existing_log = String::new();
+fn spawn_gui_update_thread(
+    win: Arc<tauri::Window>,
+    install_handle: thread::JoinHandle<anyhow::Result<()>>,
+    log_path: &'static Path,
+) -> thread::JoinHandle<anyhow::Result<()>> {
+    let mut existing_log = String::new();
+    thread::spawn(move || {
         loop {
             // Install log should be created once the install thread starts running,
             // otherwise we'll keep waiting.
-            let Some(mut log_file) = LOG_FILE.get().and_then(|path| {
-                fs::OpenOptions::new()
-                    .read(true)
-                    .append(true)
-                    .open(path)
-                    .ok()
-            }) else {
+            let mut log_file = if log_path.is_file() {
+                fs::OpenOptions::new().read(true).open(log_path)?
+            } else {
                 continue;
             };
 
             if let Some(new_content) = get_new_log_content(&mut existing_log, &mut log_file) {
-                window_clone.emit("install-details", new_content)?;
+                win.emit("install-details", new_content)?;
             }
 
-            if install_thread.is_finished() {
-                return if let Err(known_error) = install_thread
+            if install_handle.is_finished() {
+                return if let Err(known_error) = install_handle
                     .join()
                     .expect("unexpected error occurs when running installation thread.")
                 {
                     let error_str = known_error.to_string();
-
-                    // Write this error to log file
-                    log_file.write_all(error_str.as_bytes())?;
-
-                    window_clone.emit("install-failed", format!("ERROR: {error_str}"))?;
+                    win.emit("install-failed", error_str.clone())?;
                     Err(known_error)
                 } else {
                     Ok(())
@@ -198,15 +198,14 @@ fn install_toolchain(
 
             thread::sleep(Duration::from_millis(50));
         }
-    });
+    })
+}
 
-    if log_collector_thread.is_finished() {
-        log_collector_thread
-            .join()
-            .expect("unexpected error occurs when handling installation progress")?;
-    }
-
-    Ok(())
+fn log_file_path(install_dir: &str) -> &'static Path {
+    LOG_FILE.get_or_init(|| {
+        utils::ensure_dir(install_dir).expect("unable to create install dir");
+        PathBuf::from(install_dir).join("install.log")
+    })
 }
 
 fn get_new_log_content(old_content: &mut String, file: &mut File) -> Option<String> {

--- a/installer/src-tauri/src/installer_mode.rs
+++ b/installer/src-tauri/src/installer_mode.rs
@@ -19,8 +19,6 @@ use rim::{try_it, utils, InstallConfiguration};
 static LOG_FILE: OnceLock<PathBuf> = OnceLock::new();
 
 pub(super) fn main() -> Result<()> {
-    super::hide_console();
-
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             super::close_window,

--- a/installer/src-tauri/src/main.rs
+++ b/installer/src-tauri/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 #[macro_use]
 extern crate rust_i18n;
 
@@ -60,14 +62,6 @@ impl Mode {
 
 fn main() -> Result<()> {
     Mode::detect().run()
-}
-
-/// Prevents additional console window on Windows in release
-fn hide_console() {
-    #[cfg(all(windows, not(debug_assertions)))]
-    unsafe {
-        winapi::um::wincon::FreeConsole();
-    }
 }
 
 #[tauri::command]

--- a/installer/src-tauri/src/manager_mode.rs
+++ b/installer/src-tauri/src/manager_mode.rs
@@ -5,8 +5,6 @@ use anyhow::Context;
 use rim::{utils::Progress, UninstallConfiguration};
 
 pub(super) fn main() -> Result<()> {
-    super::hide_console();
-
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             super::close_window,

--- a/installer/src-tauri/src/manager_mode.rs
+++ b/installer/src-tauri/src/manager_mode.rs
@@ -64,20 +64,30 @@ fn uninstall_toolkit(window: tauri::Window, remove_self: bool) -> Result<()> {
         Ok(())
     });
 
-    if uninstall_thread.is_finished() {
-        return if let Err(known_error) = uninstall_thread
-            .join()
-            .expect("unexpected error occurs when processing uninstallation.")
-        {
-            let error_str = known_error.to_string();
-            window_clone
-                .emit("uninstall-failed", error_str.clone())
-                .expect("failed to emit message");
-            Err(known_error.into())
-        } else {
-            Ok(())
-        };
-    }
+    let gui_thread = spawn_gui_update_thread(window_clone, uninstall_thread);
 
+    if gui_thread.is_finished() {
+        gui_thread.join().expect("failed to join GUI thread")?;
+    }
     Ok(())
+}
+
+fn spawn_gui_update_thread(
+    win: Arc<tauri::Window>,
+    core_thread: thread::JoinHandle<anyhow::Result<()>>,
+) -> thread::JoinHandle<anyhow::Result<()>> {
+    thread::spawn(move || loop {
+        if core_thread.is_finished() {
+            return if let Err(known_error) = core_thread
+                .join()
+                .expect("failed to join uninstallation thread.")
+            {
+                let error_str = known_error.to_string();
+                win.emit("uninstall-failed", error_str.clone())?;
+                Err(known_error)
+            } else {
+                Ok(())
+            };
+        }
+    })
 }

--- a/installer/uno.config.ts
+++ b/installer/uno.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
     presetUno(),
     presetAttributify(),
     presetIcons({
-      extraProperties: { display: 'inline-block', verticalAlign: 'middle' },
+      extraProperties: { display: 'inline-block', "vertical-align": 'middle' },
     }),
     presetTypography(),
     presetWebFonts({

--- a/rim_dev/Cargo.toml
+++ b/rim_dev/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+cfg-if = "1"
 rust-i18n.workspace = true

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::cli::common::{self, Confirm};
 use crate::components::Component;
 use crate::core::install::{
-    default_rustup_dist_server, default_rustup_update_root, EnvConfig, InstallConfiguration,
+    default_rustup_dist_server, default_rustup_update_root, InstallConfiguration,
     DEFAULT_CARGO_REGISTRY,
 };
 use crate::core::try_it;
@@ -47,7 +47,7 @@ pub(super) fn execute_installer(installer: &Installer) -> Result<()> {
         .unwrap_or(DEFAULT_CARGO_REGISTRY);
     let install_dir = user_opt.prefix;
 
-    let mut config = InstallConfiguration::init(&install_dir, false, None)?
+    InstallConfiguration::init(&install_dir, false, None)?
         .cargo_registry(registry_name, registry_value)
         .rustup_dist_server(
             rustup_dist_server
@@ -58,15 +58,8 @@ pub(super) fn execute_installer(installer: &Installer) -> Result<()> {
             rustup_update_root
                 .clone()
                 .unwrap_or_else(|| default_rustup_update_root().clone()),
-        );
-    config.config_env_vars(&manifest)?;
-    config.config_cargo()?;
-
-    // This step taking cares of requirements, such as `MSVC`, also third-party app such as `VS Code`.
-    config.install_tools(&manifest, &user_opt.toolset)?;
-    config.install_rust(&manifest, &user_opt.toolchain_components)?;
-    // install third-party tools via cargo that got installed by rustup
-    config.cargo_install(&user_opt.toolset)?;
+        )
+        .install(user_opt.toolchain_components, user_opt.toolset)?;
 
     println!("\n{}\n", t!("install_finish_info"));
 

--- a/src/core/custom_instructions/buildtools.rs
+++ b/src/core/custom_instructions/buildtools.rs
@@ -41,7 +41,7 @@ pub(super) fn install(path: &Path, config: &InstallConfiguration) -> Result<Vec<
 
     // Step 3: Invoke the install command.
     println!("{}", t!("installing_msvc_info"));
-    let exit_code: VSExitCode = utils::execute_for_ret_code(buildtools_exe, &cmd)?.into();
+    let exit_code: VSExitCode = utils::Command::new(buildtools_exe).args(&cmd).run_with_ret_code()?.into();
     match exit_code {
         VSExitCode::Success => {
             println!("info: {}", exit_code);

--- a/src/core/custom_instructions/vscode.rs
+++ b/src/core/custom_instructions/vscode.rs
@@ -72,7 +72,11 @@ impl VSCodeInstaller<'_> {
                 utils::path_to_str(&shortcut_path)?,
                 utils::path_to_str(&target_path)?,
             );
-            if utils::execute("powershell.exe", &[weird_powershell_cmd]).is_err() {
+            if utils::Command::new("powershell")
+                .arg(weird_powershell_cmd)
+                .run()
+                .is_err()
+            {
                 show_failure_warning();
             }
         }

--- a/src/core/tools.rs
+++ b/src/core/tools.rs
@@ -196,12 +196,12 @@ fn cargo_install_or_uninstall(op: &str, args: &[&str], cargo_home: &Path) -> Res
     cargo_bin.push("bin");
     cargo_bin.push(format!("cargo{}", std::env::consts::EXE_SUFFIX));
 
-    let mut full_args = vec![op];
-    full_args.extend_from_slice(args);
-
-    let cargo_home = utils::path_to_str(cargo_home)?;
-
-    utils::execute_with_env(cargo_bin, &full_args, [(CARGO_HOME, cargo_home)])
+    utils::Command::new(cargo_bin)
+        .arg(op)
+        .args(args)
+        .env(CARGO_HOME, cargo_home)
+        .inherit_stderr()
+        .run()
 }
 
 /// Installing [`ToolInstaller::DirWithBin`], with a couple steps:
@@ -270,10 +270,11 @@ impl PluginType {
                                 program = program
                             )
                         );
-                        match utils::execute(
-                            program,
-                            &[arg_opt.as_str(), utils::path_to_str(plugin_path)?],
-                        ) {
+                        match utils::Command::new(program)
+                            .arg(arg_opt)
+                            .arg(plugin_path)
+                            .run()
+                        {
                             Ok(()) => continue,
                             // Ignore error when uninstalling.
                             Err(_) if uninstall => {

--- a/src/core/tools.rs
+++ b/src/core/tools.rs
@@ -291,6 +291,11 @@ impl PluginType {
                         }
                     }
                 }
+
+                // Remove the plugin file if uninstalling
+                if uninstall {
+                    utils::remove(plugin_path)?;
+                }
             }
         }
         Ok(())

--- a/src/core/try_it.rs
+++ b/src/core/try_it.rs
@@ -1,4 +1,5 @@
-use crate::{core::tools::VSCODE_FAMILY, utils};
+use crate::core::tools::VSCODE_FAMILY;
+use crate::utils;
 use anyhow::Result;
 use std::{
     env,
@@ -37,7 +38,9 @@ pub fn try_it(path: Option<&Path>) -> Result<()> {
         .find_map(|p| utils::cmd_exist(p).then_some(*p))
         .unwrap_or(file_explorer);
     // Try to open the project, but don't do anything if it fails cuz it's pretty noisy.
-    _ = utils::execute(program, &[&example_dir]);
+    _ = utils::Command::new_shell_command(program)
+        .arg(example_dir)
+        .run();
 
     Ok(())
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,7 +9,10 @@ mod file_system;
 mod process;
 mod progress_bar;
 
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
 pub use download::download;
 pub use extraction::Extractable;
@@ -64,4 +67,11 @@ pub fn lowercase_program_name() -> Option<String> {
         .file_name()
         .and_then(|oss| oss.to_str())?;
     Some(program_name.to_lowercase())
+}
+
+/// Lossy convert any [`OsStr`] representation into [`String`].
+///
+/// Check [`OsStr::to_string_lossy`] for detailed conversion.
+pub fn to_string_lossy<S: AsRef<OsStr>>(s: S) -> String {
+    s.as_ref().to_string_lossy().to_string()
 }

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -1,9 +1,13 @@
 use std::env;
 use std::ffi::OsStr;
-use std::fmt::Debug;
-use std::process::{Command, Stdio};
+use std::process::{Command as StdCommand, Stdio};
+use std::sync::Mutex;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
+
+use super::to_string_lossy;
+
+static COMMAND_STRING: Mutex<Vec<String>> = Mutex::new(Vec::new());
 
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
@@ -15,19 +19,76 @@ cfg_if::cfg_if! {
     }
 }
 
-macro_rules! exec_err {
-    ($p:expr, $args:expr, $ext_msg:expr) => {
-        anyhow::anyhow!(
-            "error occured when executing command `{} {}`{}",
-            $p.as_ref().to_string_lossy().to_string(),
-            $args
-                .iter()
-                .map(|oss| oss.as_ref().to_string_lossy().to_string())
-                .collect::<std::vec::Vec<_>>()
-                .join(" "),
-            $ext_msg
-        )
-    };
+/// A [`std::process::Command`] wrapper type that supports better error reporting.
+pub struct Command(StdCommand);
+
+impl Command {
+    pub fn new<P: AsRef<OsStr>>(program: P) -> Self {
+        let mut guard = COMMAND_STRING.lock().unwrap();
+        *guard = vec![to_string_lossy(&program)];
+
+        Self(StdCommand::new(program))
+    }
+    /// Create a command that will be execute using a separated shell.
+    ///
+    /// This prevents a specific program being shut down because the main process exists.
+    pub fn new_shell_command<P: AsRef<OsStr>>(program: P) -> Self {
+        let mut guard = COMMAND_STRING.lock().unwrap();
+        *guard = vec![to_string_lossy(&program)];
+
+        let mut inner = StdCommand::new(SHELL);
+        inner.arg(START_ARG).arg(program);
+
+        Self(inner)
+    }
+    pub fn arg<A: AsRef<OsStr>>(&mut self, arg: A) -> &mut Self {
+        let mut guard = COMMAND_STRING.lock().unwrap();
+        (*guard).push(to_string_lossy(&arg));
+
+        self.0.arg(arg);
+        self
+    }
+    pub fn args<S: AsRef<OsStr>>(&mut self, args: &[S]) -> &mut Self {
+        let mut guard = COMMAND_STRING.lock().unwrap();
+        for arg in args {
+            (*guard).push(to_string_lossy(arg));
+        }
+
+        self.0.args(args);
+        self
+    }
+    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        let mut guard = COMMAND_STRING.lock().unwrap();
+        (*guard).insert(
+            0,
+            format!("{}={}", to_string_lossy(&key), to_string_lossy(&val)),
+        );
+
+        self.0.env(key, val);
+        self
+    }
+    /// Use [`Stdio::inherit`] for standard error output.
+    ///
+    /// For some program, such as `rustup` or `cargo`, putting `info:` messages in `stderr` (WHY!!!),
+    /// therefore we can specify this to output those `info` as well, but this will causing
+    /// the actually error not showing when error occurs.
+    pub fn inherit_stderr(&mut self) -> &mut Command {
+        self.0.stderr(Stdio::inherit());
+        self
+    }
+
+    pub fn run(&mut self) -> Result<()> {
+        execute_command(&mut self.0, true)?;
+        Ok(())
+    }
+
+    pub fn run_with_ret_code(&mut self) -> Result<i32> {
+        execute_command(&mut self.0, false)
+    }
 }
 
 /// Check if a command/program exist in the `PATH`.
@@ -38,152 +99,39 @@ pub fn cmd_exist(cmd: &str) -> bool {
         .any(|p| p.exists())
 }
 
-pub fn execute_for_ret_code<P, A>(program: P, args: &[A]) -> Result<i32>
-where
-    P: AsRef<OsStr> + Debug,
-    A: AsRef<OsStr>,
-{
-    shell_execute_with_env(program, args, [], false)
-}
+fn execute_command(command: &mut StdCommand, expect_success: bool) -> Result<i32> {
+    command.stdout(Stdio::inherit());
 
-/// Execute a commands using [`Command`] api.
-///
-/// # Platform specific behaviors:
-/// - On Windows, this will launch a `cmd.exe` process and invoke the command there.
-/// - On Linux, this invoke the command directly.
-///
-/// # Errors
-///
-/// This will return errors if:
-/// 1. The specific command cannot be execute.
-/// 2. The command was executed but failed.
-pub fn execute<P, A>(program: P, args: &[A]) -> Result<()>
-where
-    P: AsRef<OsStr> + Debug,
-    A: AsRef<OsStr>,
-{
-    #[cfg(windows)]
-    shell_execute_with_env(program, args, [], true)?;
-    #[cfg(not(windows))]
-    execute_program_with_env(program, args, [])?;
-
-    Ok(())
-}
-
-/// Execute a commands using [`Command`] api, with environment variables.
-///
-/// # Platform specific behaviors:
-/// - On Windows, this will launch a `cmd.exe` process and invoke the command there.
-/// - On Linux, this invoke the command directly.
-///
-/// # Errors
-///
-/// This will return errors if:
-/// 1. The specific command cannot be execute.
-/// 2. The command was executed but failed.
-pub fn execute_with_env<'a, P, A, I>(program: P, args: &[A], envs: I) -> Result<()>
-where
-    P: AsRef<OsStr> + Debug,
-    A: AsRef<OsStr>,
-    I: IntoIterator<Item = (&'a str, &'a str)>,
-{
-    #[cfg(windows)]
-    shell_execute_with_env(program, args, envs, true)?;
-    #[cfg(not(windows))]
-    execute_program_with_env(program, args, envs)?;
-
-    Ok(())
-}
-
-/// Execute commands by directly invoking program, with environment variables.
-///
-/// # Errors
-///
-/// This will return errors if:
-/// 1. The specific command cannot be execute.
-/// 2. The command was executed but failed.
-pub fn execute_program_with_env<'a, P, A, I>(program: P, args: &[A], envs: I) -> Result<()>
-where
-    P: AsRef<OsStr> + Debug,
-    A: AsRef<OsStr>,
-    I: IntoIterator<Item = (&'a str, &'a str)>,
-{
-    let mut command = Command::new(program.as_ref());
-    command
-        .args(args)
-        .envs(envs)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-
-    // Prevent CMD window popup
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        command.creation_flags(winapi::um::winbase::CREATE_NO_WINDOW);
+    cfg_if::cfg_if! {
+        if #[cfg(windows)] {
+            use std::os::windows::process::CommandExt;
+            use winapi::um::winbase::CREATE_NO_WINDOW;
+            // Prevent CMD window popup
+            let output = command.creation_flags(CREATE_NO_WINDOW).output()?;
+            let ret_code = output.status.code().unwrap();
+        } else {
+            use std::os::unix::process::ExitStatusExt;
+            let output = command.output()?;
+            let ret_code = output.status.into_raw();
+        }
     }
 
-    let output = command
-        .output()
-        .with_context(|| exec_err!(program, args, ""))?;
-    // 检查子进程的退出状态
-    if !output.status.success() {
+    if expect_success && !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(exec_err!(program, args, stderr));
-    }
-
-    Ok(())
-}
-
-/// Execute commands by invoking shell program, such as `sh` on Unix, `cmd` on Windows.
-///
-/// # Errors
-///
-/// This will return errors if:
-/// 1. The specific command cannot be execute.
-/// 2. The command was executed but failed.
-fn shell_execute_with_env<'a, P, A, I>(
-    program: P,
-    args: &[A],
-    vars: I,
-    expect_success: bool,
-) -> Result<i32>
-where
-    P: AsRef<OsStr> + Debug,
-    A: AsRef<OsStr>,
-    I: IntoIterator<Item = (&'a str, &'a str)>,
-{
-    let mut command = Command::new(SHELL);
-    command
-        .arg(START_ARG)
-        .arg(&program)
-        .args(args)
-        .envs(vars)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-
-    // Prevent CMD window popup
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        command.creation_flags(winapi::um::winbase::CREATE_NO_WINDOW);
-    }
-
-    let output = command
-        .output()
-        .with_context(|| exec_err!(program, args, ""))?;
-
-    if !expect_success {
-        output.status.code().ok_or_else(|| {
-            anyhow!(
-                "failed to retrive exit code because the program {:?} was terminated by a signal",
-                program.as_ref()
-            )
-        })
-    } else if !output.status.success() {
-        // 检查子进程的退出状态
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(exec_err!(program, args, stderr))
+        // stderr might be empty if using `Stdio::inherit()`
+        let err = if stderr.is_empty() {
+            "Undocumented error, check log for more details"
+        } else {
+            &*stderr
+        };
+        let command = COMMAND_STRING.lock().unwrap();
+        anyhow::bail!(
+            "programm exited with code {ret_code}. \n\
+            Command: {}
+            Error output: {err}",
+            (*command).join(" "),
+        );
     } else {
-        Ok(0)
+        Ok(ret_code)
     }
 }


### PR DESCRIPTION
check commit messages for what's changed.

Note: This PR breaks the `--no-gui` functionality for GUI app by bringing back the `windows_subsystem = "windows"` attribute. Because it's needed to fix the `try-it`, which sometimes does not open vscode window after selecting "open example project after imstallation''.

We'll need to figure out another way to enable ''--no-gui'' in.the future